### PR TITLE
When using worker threads, changes to GUI elements must be handled throu...

### DIFF
--- a/python/browser_widget/browser_widget.py
+++ b/python/browser_widget/browser_widget.py
@@ -120,8 +120,8 @@ class BrowserWidget(QtGui.QWidget):
         self._app = app
         # set up worker queue
         self._worker = Worker(app)
-        self._worker.work_completed.connect( self._on_worker_signal)
-        self._worker.work_failure.connect( self._on_worker_failure)
+        self._worker.work_completed.connect(self._on_worker_signal, QtCore.Qt.QueuedConnection)
+        self._worker.work_failure.connect(self._on_worker_failure, QtCore.Qt.QueuedConnection)
         
         self._worker.start()
         

--- a/python/browser_widget/list_item.py
+++ b/python/browser_widget/list_item.py
@@ -74,8 +74,8 @@ class ListItem(ListBase):
             self._timer.start(100)
             
             self._worker_uid = self._worker.queue_work(self._download_thumbnail, {"url": url})
-            self._worker.work_completed.connect(self._on_worker_task_complete)
-            self._worker.work_failure.connect( self._on_worker_failure)
+            self._worker.work_completed.connect(self._on_worker_task_complete, QtCore.Qt.QueuedConnection)
+            self._worker.work_failure.connect(self._on_worker_failure, QtCore.Qt.QueuedConnection)
         else:
             # assume url is a path on disk or resource
             self.ui.thumbnail.setPixmap(QtGui.QPixmap(url))


### PR DESCRIPTION
...gh queued connection to enforce their execution by the main thread. Otherwise it will be the worker thread updating GUI elements, which is an error and will destabilize the host application.
