### PR TITLE
#21895 Updated thumbnail download to use new core method.

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -24,7 +24,7 @@ description: "Collection of standard Shotgun Pipeline Toolkit Related Q-Widgets.
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.12.14"
+requires_core_version: "v0.14.35"
 
  
         


### PR DESCRIPTION
The framework now uses the newly introduced download method in the core api. Note that this pull request should not be pulled in before the required version of core has gone out.
