### PR TITLE
Fix pyqtSignal compatibility issue with PyQt 4.7.4 and later.

### DIFF
--- a/python/browser_widget/worker.py
+++ b/python/browser_widget/worker.py
@@ -27,7 +27,7 @@ class Worker(QtCore.QThread):
     # thread to terminate before returning from 'stop()'
     _SGTK_IMPLEMENTS_QTHREAD_CRASH_FIX_=True    
     
-    work_completed = QtCore.Signal(str, dict)
+    work_completed = QtCore.Signal(str, object)
     work_failure = QtCore.Signal(str, str)
     
     def __init__(self, app, parent=None):


### PR DESCRIPTION
This is a fix for https://support.shotgunsoftware.com/hc/en-us/requests/83532

The issue is noted here under the PyQt4 v4.7.4 heading:
http://pyqt.sourceforge.net/Docs/PyQt4/incompatibilities.html
The new OS we're testing uses PyQt 4.10.1.

This has passed regression testing in our current production OS, which uses PyQt 4.6.2.